### PR TITLE
Fix for Git Ignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ Thumbs.db
 *.dll
 *.exe
 
+# Other
+moc_predefs.h
+starrtracker


### PR DESCRIPTION
Made a minor modification for the `.gitignore` file generated by Qt Creator to allow us to manually control the build process using QMake.